### PR TITLE
Update clinvar.yaml

### DIFF
--- a/data-sources/clinvar.yaml
+++ b/data-sources/clinvar.yaml
@@ -30,6 +30,7 @@ license-commentary:
     - 'Custom PD declaration.'
     - 'The license page section \"Molecular Data Usage\" states that\: \"NCBI is not in a position to assess the validity of such claims and since there is no transfer of rights from submitters to NCBI, NCBI has no rights to transfer to a third party. Therefore, NCBI cannot provide comment or unrestricted permission concerning the use, copying, or distribution of the information contained in the molecular databases.\"'
     - 'We also considered the wording at https://www.ncbi.nlm.nih.gov/clinvar/docs/maintenance_use/ , but decided that the one we chose above was mostly likely indended and correct.'
-was-controversial: "false"
+    - 'We turned on the \"controversial\" flag for this resource due to the unclear nature of sumbitted data. While the stated intent seems to have the data available as PD, ClinVar does not require a copyright reassignment and explicitly states that they cannot vouch for submitted data, which rather undermines any PD-style statement. We were intitially intending on adding a B.1 violation as ClinVar would be acting more like a directory than a unified resource, possibly requiring negotiation with upstream resources.'
+was-controversial: "true"
 contacts:
     - info@ncbi.nlm.nih.gov

--- a/data-sources/clinvar.yaml
+++ b/data-sources/clinvar.yaml
@@ -4,7 +4,7 @@ source-link: 'https://www.ncbi.nlm.nih.gov/clinvar/'
 source-type: 'integrator'
 status: complete
 description: 'ClinVar archives and aggregates information about relationships among variation and human health. ClinVar collects reports of variants found in patient samples, assertions made regarding their clinical significance, information about the submitter, and other supporting data.'
-last-curated: '2017-12-06'
+last-curated: '2017-12-07'
 data-field: biomedical
 data-type: human
 data-categories:

--- a/data-sources/clinvar.yaml
+++ b/data-sources/clinvar.yaml
@@ -13,17 +13,23 @@ data-categories:
     - 'variant definitions'
 data-access:
     - type: download
-      location: 'https://www.ncbi.nlm.nih.gov/clinvar/docs/maintenance_use/'
+      location: 'https://www.ncbi.nlm.nih.gov/home/about/policies/'
 license: custom
-license-type: 'permissive'
+license-type: 'public domain'
 license-link: 'http://www.ncbi.nlm.nih.gov/clinvar/docs/maintenance_use/'
 license-hat-used: "false"
 license-issues:
     - criteria: A.2
-      comment: 'After a search, no direct licensing or terms were found, rather mentions of the free availablility of the data; we used the most direct apparent mention at "Data sharing" on https://www.ncbi.nlm.nih.gov/clinvar/intro/ .'
+      comment: 'Public domain declaration'
+    - criteria: B.2.1
+      comment: 'The license page section \"Molecular Data Usage\" states that all data may not be covered under the public domain (see comments).'
+    - criteria: B.2.2
+      comment: 'There does not seem to be any easy way to differentiate the \"clean\" data.'
 license-commentary:
     - 'While an API is offered through E-Utilities, we will evaluate the more concrete downloads given their ease.'
-    - 'Given the nebulous nature of whether or not http://www.ncbi.nlm.nih.gov/clinvar/docs/maintenance_use constitutes a \"custom\" license, we may want to revisit.'
+    - 'Custom PD declaration.'
+    - 'The license page section \"Molecular Data Usage\" states that\: \"NCBI is not in a position to assess the validity of such claims and since there is no transfer of rights from submitters to NCBI, NCBI has no rights to transfer to a third party. Therefore, NCBI cannot provide comment or unrestricted permission concerning the use, copying, or distribution of the information contained in the molecular databases.\"'
+    - 'We also considered the wording at https://www.ncbi.nlm.nih.gov/clinvar/docs/maintenance_use/ , but decided that the one we chose above was mostly likely indended and correct.'
 was-controversial: "false"
 contacts:
     - info@ncbi.nlm.nih.gov

--- a/data-sources/clinvar.yaml
+++ b/data-sources/clinvar.yaml
@@ -1,8 +1,10 @@
 id: clinvar
 source: ClinVar
-source-link: 'TODO'
-status: incomplete
+source-link: 'https://www.ncbi.nlm.nih.gov/clinvar/'
+source-type: 'integrator'
+status: complete
 description: 'ClinVar archives and aggregates information about relationships among variation and human health. ClinVar collects reports of variants found in patient samples, assertions made regarding their clinical significance, information about the submitter, and other supporting data.'
+last-curated: '2017-12-06'
 data-field: biomedical
 data-type: human
 data-categories:
@@ -11,17 +13,17 @@ data-categories:
     - 'variant definitions'
 data-access:
     - type: download
-      location: https://www.ncbi.nlm.nih.gov/clinvar/docs/ftp_primer/
-license: unknown
-license-type: 'public domain'
+      location: 'https://www.ncbi.nlm.nih.gov/clinvar/docs/maintenance_use/'
+license: custom
+license-type: 'permissive'
 license-link: 'http://www.ncbi.nlm.nih.gov/clinvar/docs/maintenance_use/'
+license-hat-used: "false"
 license-issues:
-    - {criteria: A.2, comment: 'public domain'}
-    - {criteria: B.1}
-    - {criteria: B.2.1}
-    - {criteria: B.2.2}
+    - criteria: A.2
+      comment: 'After a search, no direct licensing or terms were found, rather mentions of the free availablility of the data; we used the most direct apparent mention at "Data sharing" on https://www.ncbi.nlm.nih.gov/clinvar/intro/ .'
 license-commentary:
-    - 'Information that is created by or for the US government on this site is within the public domain. Public domain information on the National Library of Medicine (NLM) Web pages may be freely distributed and copied. However, it is requested that in any subsequent use of this work, NLM be given appropriate acknowledgment.'
-    - 'NOTE: This site contains resources which incorporate material contributed or licensed by individuals, companies, or organizations that may be protected by U.S. and foreign copyright laws. These include, but are not limited to PubMed Health (see PubMed Health Copyright and Restrictions Notice), PubMed Central (PMC) (see PMC Copyright Notice), Bookshelf (see Bookshelf Copyright Notice), OMIM (see OMIM Copyright Status), and PubChem. All persons reproducing, redistributing, or making commercial use of this information are expected to adhere to the terms and conditions asserted by the copyright holder. Transmission or reproduction of protected items beyond that allowed by fair use (PDF) as defined in the copyright laws requires the written permission of the copyright owners.'
+    - 'While an API is offered through E-Utilities, we will evaluate the more concrete downloads given their ease.'
+    - 'Given the nebulous nature of whether or not http://www.ncbi.nlm.nih.gov/clinvar/docs/maintenance_use constitutes a \"custom\" license, we may want to revisit.'
+was-controversial: "false"
 contacts:
     - info@ncbi.nlm.nih.gov

--- a/data-sources/clinvar.yaml
+++ b/data-sources/clinvar.yaml
@@ -26,11 +26,11 @@ license-issues:
     - criteria: B.2.2
       comment: 'There does not seem to be any easy way to differentiate the \"clean\" data.'
 license-commentary:
+    - 'We turned on the \"controversial\" flag for this resource due to the unclear nature of sumbitted data. While the stated intent seems to have the data available as PD, ClinVar does not require a copyright reassignment and explicitly states that they cannot vouch for submitted data, which rather undermines any PD-style statement. We were intitially intending on adding a B.1 violation as ClinVar would be acting more like a directory than a unified resource, possibly requiring negotiation with upstream resources.'
     - 'While an API is offered through E-Utilities, we will evaluate the more concrete downloads given their ease.'
     - 'Custom PD declaration.'
     - 'The license page section \"Molecular Data Usage\" states that\: \"NCBI is not in a position to assess the validity of such claims and since there is no transfer of rights from submitters to NCBI, NCBI has no rights to transfer to a third party. Therefore, NCBI cannot provide comment or unrestricted permission concerning the use, copying, or distribution of the information contained in the molecular databases.\"'
     - 'We also considered the wording at https://www.ncbi.nlm.nih.gov/clinvar/docs/maintenance_use/ , but decided that the one we chose above was mostly likely indended and correct.'
-    - 'We turned on the \"controversial\" flag for this resource due to the unclear nature of sumbitted data. While the stated intent seems to have the data available as PD, ClinVar does not require a copyright reassignment and explicitly states that they cannot vouch for submitted data, which rather undermines any PD-style statement. We were intitially intending on adding a B.1 violation as ClinVar would be acting more like a directory than a unified resource, possibly requiring negotiation with upstream resources.'
 was-controversial: "true"
 contacts:
     - info@ncbi.nlm.nih.gov


### PR DESCRIPTION
The following two references were in there from the original curation:

    - 'Information that is created by or for the US government on this site is within the public domain. Public domain information on the National Library of Medicine (NLM) Web pages may be freely distributed and copied. However, it is requested that in any subsequent use of this work, NLM be given appropriate acknowledgment.'
    - 'This site contains resources which incorporate material contributed or licensed by individuals, companies, or organizations that may be protected by U.S. and foreign copyright laws. These include, but are not limited to PubMed Health (see PubMed Health Copyright and Restrictions Notice), PubMed Central (PMC) (see PMC Copyright Notice), Bookshelf (see Bookshelf Copyright Notice), OMIM (see OMIM Copyright Status), and PubChem. All persons reproducing, redistributing, or making commercial use of this information are expected to adhere to the terms and conditions asserted by the copyright holder. Transmission or reproduction of protected items beyond that allowed by fair use (PDF) as defined in the copyright laws requires the written permission of the copyright owners.'

Doing a Google search for parts of these texts on ClinVar (e.g. `site:https://www.ncbi.nlm.nih.gov/clinvar/ "public domain"`) turned up nothing, so I removed them and updated the criteria violations. Does anybody remember where these might have been? Or maybe ClinVar updated?

I also wonder, given the vague nature of the "license" for ClinVar if it might not just be a short-circuit `A.1.1` or `A.1.2` violation. Currently, given the PD nature of the site, I believe the intent is there, but I do not feel strongly about that at all. Anybody else?