### PR TITLE
Fix typos in license commentary fields

### DIFF
--- a/data.json
+++ b/data.json
@@ -752,12 +752,12 @@
             }
         ],
         "license-commentary": [
-            "There are statements made in the Additional Terms of Data Use that would make it very difficult to re-use the data provided without a air amount o coordination with the resource and changes to information handling."
+            "There are statements made in the Additional Terms of Data Use that would make it very difficult to re-use the data provided without a fair amount of coordination with the resource and changes to information handling."
         ],
         "contacts": [
             "http://ctdbase.org/help/contact.go"
         ],
-        "license-commentary-embeddable": "There are statements made in the Additional Terms of Data Use that would make it very difficult to re-use the data provided without a air amount o coordination with the resource and changes to information handling.",
+        "license-commentary-embeddable": "There are statements made in the Additional Terms of Data Use that would make it very difficult to re-use the data provided without a fair amount of coordination with the resource and changes to information handling.",
         "data-tags": "biology, x-species, disease-gene association",
         "grade-automatic": 2.5
     },


### PR DESCRIPTION
Corrected 'air amount o' to 'fair amount of' in the license-commentary and license-commentary-embeddable fields in data.json.