### PR TITLE
Add /evaluate and /cross-check slash commands

### DIFF
--- a/.claude/commands/cross-check.md
+++ b/.claude/commands/cross-check.md
@@ -1,0 +1,31 @@
+---
+description: Re-examine an existing evaluation by generating a fresh trace from the resource website
+allowed-tools: WebFetch, Read, Glob, Grep
+---
+
+Cross-check the existing evaluation for resource: $ARGUMENTS
+
+This command re-examines an existing evaluation by generating a fresh trace from the resource website and comparing it against the current YAML. **Do NOT modify the existing YAML file.**
+
+Steps:
+
+1. **Read the existing evaluation** at `data-sources/$ARGUMENTS.yaml`.
+2. **Read the criteria** from `docs/criteria.md` and the schema from `scripts/source.schema.yaml`.
+3. **Fetch the resource root URL** (from `source-link` in the YAML) and catalog all navigation links.
+4. **Follow links** to find licensing and data-access information, recording navigation paths as in a full evaluation.
+5. **Evaluate each criterion** (A.1.1 through E.1.2) based on the current website state.
+6. **Compare** your fresh findings against the existing YAML evaluation:
+   - Note any criteria where your assessment differs from the existing evaluation.
+   - Note any licensing text changes, new/removed licenses, or access changes.
+   - Note if commentary in the YAML is still accurate.
+7. **Report differences** clearly, organized by criterion. For each difference, show:
+   - The existing YAML value/assessment
+   - What the current website shows
+   - The evidence (quoted text and source URL via navigation path)
+8. If there are no differences, confirm the evaluation appears current.
+
+Important:
+- Follow all Evaluation Guidelines from CLAUDE.md.
+- Every source URL must be reachable via a documented navigation path from the root.
+- Quotes must be verbatim text from the fetched page.
+- Do NOT modify the existing YAML — report only.

--- a/.claude/commands/evaluate.md
+++ b/.claude/commands/evaluate.md
@@ -1,0 +1,26 @@
+---
+description: Create a provisional evaluation and trace for a new resource
+allowed-tools: WebFetch, Read, Write, Edit, Bash(make check:*), Glob, Grep
+---
+
+Create a provisional evaluation and trace for the resource at: $ARGUMENTS
+
+Follow the full evaluation procedure from CLAUDE.md:
+
+1. **Fetch the resource root URL** and catalog all navigation links (text, location on page, destination URL).
+2. **Follow links** to find licensing and data-access information. Record every hop as a navigation path. Only pages reachable by normal human navigation from the root count as evidence.
+3. **Read the criteria** from `docs/criteria.md` and the schema from `scripts/source.schema.yaml`.
+4. **Read the example trace** at `data-traces/reactome-test.trace.md` to understand the expected format.
+5. **Evaluate each criterion** (A.1.1 through E.1.2) and record the verdict, source URL, quoted text, and reasoning.
+6. **Derive a resource ID** from the resource name (lowercase, hyphenated, matching existing conventions in `data-sources/`).
+7. **Write two files:**
+   - `data-sources/{id}.yaml` — the evaluation YAML (must conform to `scripts/source.schema.yaml`). Set `provisional: "true"`.
+   - `data-traces/{id}.trace.md` — the trace file (format specified in CLAUDE.md).
+8. **Validate** by running `make check`.
+
+Important:
+- Follow all Evaluation Guidelines from CLAUDE.md.
+- Every source URL in the trace must be reachable via a documented navigation path from the root.
+- Quotes must be verbatim text from the fetched page.
+- Commentary should only note findings and inconsistencies, not confirm expected or unremarkable details.
+- Evaluations are about data and data access only — software/tool licensing is out of scope.


### PR DESCRIPTION
## Summary
- Add `.claude/commands/evaluate.md` — `/evaluate [resource-url]` slash command for creating provisional evaluations with traces
- Add `.claude/commands/cross-check.md` — `/cross-check [resource-id]` slash command for re-examining existing evaluations against current website state

These are the command definition files for the skills documented in CLAUDE.md (added in #259), so they appear as invocable slash commands in Claude Code.

## Test plan
- [ ] Restart Claude Code and verify `/evaluate` and `/cross-check` appear in the slash command list
- [ ] Test `/evaluate` with a resource URL
- [ ] Test `/cross-check` with an existing resource ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)