### PR TITLE
Add validation guidance to CLAUDE.md and cross-check skill

### DIFF
--- a/.claude/skills/cross-check/SKILL.md
+++ b/.claude/skills/cross-check/SKILL.md
@@ -56,6 +56,9 @@ Cross-check the existing evaluation for resource **$ARGUMENTS**.
      - The relevant quote and URL from the trace
    - Do NOT modify the evaluation YAML — only report. The user decides
      whether to update.
+   - If proposing YAML field changes, verify they would pass validation
+     by running `make check` against a temporary copy or consulting the
+     license → license-type mapping in CLAUDE.md.
 
 ## Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,15 @@ include a "public domain" value — valid values are: `unknown`,
 - **Mustache** - HTML templating
 - **esbuild** - JS bundling for explore page
 
+## Validation
+
+When writing or modifying evaluation YAML files, always run `make check`
+to validate schema conformance and consistency (license/type mappings,
+required license-issues, etc.). Fix any errors before reporting success.
+The `Makefile` is the authoritative source for available validation and
+build commands — skills should invoke these commands rather than
+duplicating validation logic.
+
 ## Evaluation Guidelines
 
 - Determinations are based on public information in the resource web presence, made at a fixed point in time and updated when the website changes.


### PR DESCRIPTION
## Summary
- Adds a "Validation" section to CLAUDE.md requiring `make check` after writing/modifying YAML, and establishing the Makefile as the authoritative source for validation commands
- Adds a verification step to the cross-check skill so proposed YAML changes are validated before reporting

This was the second commit from #261 that didn't make it into the merge.

## Test plan
- [ ] Verify CLAUDE.md contains the new Validation section
- [ ] Verify cross-check SKILL.md includes the validation step

🤖 Generated with [Claude Code](https://claude.com/claude-code)